### PR TITLE
Added max_execution_time.

### DIFF
--- a/daiv_sandbox/config.py
+++ b/daiv_sandbox/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     SENTRY_DSN: HttpUrl | None = None
     API_V1_STR: str = "/api/v1"
     ENVIRONMENT: Literal["local", "staging", "production"] = "local"
+    MAX_EXECUTION_TIME: int = 600  # seconds
 
 
 settings = Settings()  # type: ignore

--- a/daiv_sandbox/main.py
+++ b/daiv_sandbox/main.py
@@ -2,7 +2,7 @@ import io
 
 import sentry_sdk
 from fastapi import FastAPI
-from pydantic import UUID4, Base64Bytes, BaseModel
+from pydantic import UUID4, Base64Bytes, BaseModel, Field
 
 from .config import settings
 from .sessions import SandboxDockerSession
@@ -14,15 +14,17 @@ app = FastAPI(title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/o
 
 
 class RunRequest(BaseModel):
-    run_id: UUID4
-    base_image: str
-    commands: list[str]
-    archive: Base64Bytes
+    run_id: UUID4 = Field(..., description="Unique identifier for the run.")
+    base_image: str = Field(..., description="Docker image to be used as the base image for the sandbox.")
+    commands: list[str] = Field(
+        ..., description="List of commands to be executed in the root directory of the archive."
+    )
+    archive: Base64Bytes = Field(..., description="Base64-encoded archive with files to be copied to the sandbox.")
 
 
 class RunResponse(BaseModel):
-    results: dict[str, dict[str, str | int]]
-    archive: Base64Bytes | None
+    results: dict[str, dict[str, str | int]] = Field(..., description="Dictionary with the output of each command.")
+    archive: Base64Bytes | None = Field(..., description="Base64-encoded archive with the changed files.")
 
 
 @app.post("/run/commands/")


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and robustness of the `daiv_sandbox` project. The most important changes include adding a maximum execution time setting, enhancing the `RunRequest` and `RunResponse` models with descriptions, and implementing a timeout mechanism for sandbox sessions.

Enhancements to configuration and models:

* [`daiv_sandbox/config.py`](diffhunk://#diff-155b9fcc9d79e6ce1b6d9afd0bcc4a7e577b984462dbd5f277648dda92a599c9R14): Added a `MAX_EXECUTION_TIME` setting to define the maximum execution time for sandbox sessions.
* [`daiv_sandbox/main.py`](diffhunk://#diff-f022ec7d2c530007af2878f7be295001eb5833732b963ba7176eb29a3cc30775L17-R27): Enhanced the `RunRequest` and `RunResponse` models by adding descriptions to their fields using `pydantic`'s `Field` class.

Timeout mechanism implementation:

* [`daiv_sandbox/sessions.py`](diffhunk://#diff-9c0123c9f5b1a77455c18a69924468d60de156d449782e60e88f38d28a76801eR15-R26): Imported the `signal` module and added a timeout handler function. Configured the alarm signal in the `__enter__` and `__exit__` methods of the `Session` class to enforce the maximum execution time. [[1]](diffhunk://#diff-9c0123c9f5b1a77455c18a69924468d60de156d449782e60e88f38d28a76801eR15-R26) [[2]](diffhunk://#diff-9c0123c9f5b1a77455c18a69924468d60de156d449782e60e88f38d28a76801eR49-R62)

Testing improvements:

* [`tests/test_sessions.py`](diffhunk://#diff-ec16ff38dc1f97817bb79c4670e3b78aa29fd80d8cda5e7051ebd68213430e55R32-R52): Added tests to verify the context manager behavior, including the correct setting and resetting of the alarm signal and handling of the timeout exception.