### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/srtab/daiv-sandbox/security/code-scanning/3](https://github.com/srtab/daiv-sandbox/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal required permissions for all jobs. Since the workflow primarily involves installing dependencies, running linting, and executing tests, it does not require write permissions. The `contents: read` permission is sufficient for these tasks. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
