### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,9 @@
 name: Docker
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/srtab/daiv-sandbox/security/code-scanning/2](https://github.com/srtab/daiv-sandbox/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` to access repository contents.
- `packages: write` to push Docker images to the GitHub Container Registry.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
