### PR TITLE
fix(seed): init meta repo when only skills_archive is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `POST /session/{id}/seed/` now initialises the patch-extractor meta repo whenever the session was started with `extract_patch=True`, even when only `skills_archive` is provided (no `repo_archive`). Without this, the first `apply_file_mutations` or `run` call in a repoless flow failed with HTTP 500 because `/workdir/meta` was missing.
+
 ## [0.5.0] - 2026-05-04
 
 ### Added

--- a/daiv_sandbox/main.py
+++ b/daiv_sandbox/main.py
@@ -281,10 +281,12 @@ async def seed_session(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"skills_archive is invalid: {exc}"
                 ) from exc
 
-        # Meta init only when /repo was seeded — without /repo content there is nothing to snapshot.
-        if repo_archive is not None and (
-            extract_patch_session_id := cmd_executor.get_label(DAIV_SANDBOX_PATCH_EXTRACTOR_SESSION_ID_LABEL)
-        ):
+        # Meta init whenever a patch-extractor is linked (extract_patch=True at session start).
+        # Even with no repo_archive (repoless runs or skills-only seeds) the agent will mutate
+        # /repo via apply_file_mutations / bash; both endpoints run HEAD-advance and require
+        # /workdir/meta to exist. The init script's seed commit is `--allow-empty`, so an empty
+        # /workdir/new is fine.
+        if extract_patch_session_id := cmd_executor.get_label(DAIV_SANDBOX_PATCH_EXTRACTOR_SESSION_ID_LABEL):
             patch_extractor = await asyncio.to_thread(SandboxDockerSession, session_id=extract_patch_session_id)
             init_result = await asyncio.to_thread(
                 patch_extractor.execute_command, CMD_INIT_META_SCRIPT, workdir="/workdir"

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -543,7 +543,7 @@ def test_seed_session_rejects_double_seed(mock_session, client):
 
 
 def test_seed_session_extracts_skills_archive_only(mock_session, client):
-    """skills_archive only: copy_to_container hits /skills, meta init does NOT run."""
+    """skills_archive only, no patch-extractor linked: copy_to_container hits /skills, meta init skipped."""
     from docker.models.containers import ExecResult
 
     from daiv_sandbox.sessions import SKILLS_ROOT
@@ -560,8 +560,48 @@ def test_seed_session_extracts_skills_archive_only(mock_session, client):
     assert resp.status_code == 204, resp.text
     mock_session.copy_to_container.assert_called_once()
     assert mock_session.copy_to_container.call_args.kwargs.get("dest") == SKILLS_ROOT
-    # Patch-extractor meta init must not run when there is no /repo content.
+    # No patch-extractor session label → no meta init runs.
     mock_session.execute_command.assert_not_called()
+
+
+def test_seed_session_meta_init_runs_on_skills_archive_only(client):
+    """Repoless seed (skills_archive only) still inits meta when patch-extractor is linked.
+
+    Without this, the first ``apply_file_mutations`` / ``run`` call in a repoless run
+    would 500 on HEAD-advance because ``/workdir/meta`` was never initialised.
+    """
+    from docker.models.containers import ExecResult
+
+    from daiv_sandbox.main import DAIV_SANDBOX_PATCH_EXTRACTOR_SESSION_ID_LABEL
+
+    with patch("daiv_sandbox.main.SandboxDockerSession") as mock_cls:
+        mock_cmd_executor = Mock()
+        mock_cmd_executor.container = Mock()
+        mock_cmd_executor.container.exec_run.side_effect = [
+            ExecResult(exit_code=1, output=b""),  # seeded check → not seeded
+            ExecResult(exit_code=0, output=b""),  # marker write
+        ]
+        mock_cmd_executor.get_label.side_effect = lambda label: (
+            "patch-extractor-id" if label == DAIV_SANDBOX_PATCH_EXTRACTOR_SESSION_ID_LABEL else None
+        )
+
+        mock_patch_extractor = Mock()
+        mock_patch_extractor.execute_command.return_value = RunResult(
+            command="init", output="", exit_code=0, workdir="/workdir"
+        )
+
+        mock_cls.side_effect = [mock_cmd_executor, mock_patch_extractor]
+
+        resp = client.post(
+            "/session/test-session/seed/",
+            files={
+                "skills_archive": ("skills.tar", _minimal_archive_bytes("intro.md", b"# hi\n"), "application/x-tar")
+            },
+        )
+
+    assert resp.status_code == 204, resp.text
+    mock_cmd_executor.copy_to_container.assert_called_once()
+    mock_patch_extractor.execute_command.assert_called_once()
 
 
 def test_seed_session_extracts_both_archives(mock_session, client):


### PR DESCRIPTION
## Summary

- `POST /session/{id}/seed/` now initialises the patch-extractor meta repo whenever the session was started with `extract_patch=True`, even when only `skills_archive` is uploaded (no `repo_archive`).
- Before this fix, repoless agent runs in `daiv` (which seed skills-only on the first turn) would hit HTTP 500 on the next `apply_file_mutations` or `run` call, because the HEAD-advance script could not `cd` into the missing `/workdir/meta`.
- The init script's seed commit is already `--allow-empty`, so initialising against an empty `/workdir/new` is a no-op there.

## Test plan

- [x] `uv run pytest tests/unit_tests/test_main.py -k seed` — all 12 seed tests pass.
- [x] Added `test_seed_session_meta_init_runs_on_skills_archive_only` covering the repoless case.
- [x] Updated `test_seed_session_extracts_skills_archive_only` to clarify it covers the *no patch-extractor* path (meta init correctly skipped).
- [ ] Smoke test: rebuild the sandbox container, kick off a repoless chat in `daiv`, confirm the first `write_file` (or bash mutation) no longer 500s.