### PR TITLE
feat(egress): refresh a live session's egress policy without recreating the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `PUT /session/{id}/egress/` refreshes a live session's egress policy and secrets (e.g. a rotated git token) without recreating the container. The sidecar hot-reloads its config; the CA is unaffected.
 - `POST /session/{id}/seed/` — one-shot per session (409 if re-seeded), accepts archives as `multipart/form-data` fields (`repo_archive`, `skills_archive`). At least one field must be provided; `repo_archive` extracts into `/workspace/repo` and `skills_archive` into `/workspace/skills`. Replaces the former `RunRequest.archive` flow for establishing initial session state. **Breaking change**
 - `POST /session/{id}/fs/{op}` — Python-free workspace file operations (`ls`, `read`, `grep`, `glob`, `write`, `edit`, `delete`) that act anywhere under `/workspace`. `read` paginates text with `offset`/`limit` and returns binary as base64; `grep` searches with a regular expression (POSIX extended / ERE), reports an invalid pattern via the `invalid_pattern` error code, and caps results at 200 matches (setting `truncated` when more were found); `glob` supports `*`, `**`, `?`, and `[abc]`.
 - `GET /session/{id}/` — returns `204` if the session's container exists (restarting it if stopped, warming it for reuse) or `404` if it does not.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ All settings are configurable via environment variables. The available settings 
 - `POST /session/{session_id}/`: Run commands on the sandbox session.
 - `GET /session/{session_id}/`: Check session status — `204` if it exists (restarting it if stopped), else `404`.
 - `DELETE /session/{session_id}/`: Close the sandbox session (stops the container by default; `?force=true` removes it).
+- `PUT /session/{session_id}/egress/`: Refresh an egress session's policy and secrets without recreating the container (`204` success / `404` no session / `409` session has no egress proxy).
 - `GET /-/health/`: Healthcheck endpoint.
 - `GET /-/version/`: Current application version.
 
@@ -390,6 +391,10 @@ Pass an `egress` block in the `POST /session/` body to route the session through
 
 > [!NOTE]
 > A rule with `methods` set to anything other than `["*"]` causes that host to be intercepted (MITM'd) regardless of the `intercept` mode, so the method can be enforced after TLS termination. Such hosts require the shared CA, which is installed into every egress sandbox automatically.
+
+#### Refreshing egress policy on a live session
+
+`PUT /session/{id}/egress/` accepts the same body as the `egress` field on `POST /session/` and rewrites the sidecar's `config.json` atomically; the proxy hot-reloads it on the next request — no container restart needed. Returns `204` on success, `404` if the session is gone, or `409` if the session has no egress proxy (a network-isolated session has nothing to refresh). Use this to rotate credentials (e.g. a short-lived git token) without rebuilding the session.
 
 #### CA generation (operator one-time step)
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Pass an `egress` block in the `POST /session/` body to route the session through
 
 #### Refreshing egress policy on a live session
 
-`PUT /session/{id}/egress/` accepts the same body as the `egress` field on `POST /session/` and rewrites the sidecar's `config.json` atomically; the proxy hot-reloads it on the next request — no container restart needed. Returns `204` on success, `404` if the session is gone, or `409` if the session has no egress proxy (a network-isolated session has nothing to refresh). Use this to rotate credentials (e.g. a short-lived git token) without rebuilding the session.
+`PUT /session/{id}/egress/` accepts the same body as the `egress` field on `POST /session/` and rewrites the sidecar's `config.json` atomically; the proxy hot-reloads it on the next request — no container restart needed. Returns `204` on success, `404` if the session is gone, `409` if the session has no egress proxy (a network-isolated session has nothing to refresh), `422` if the policy body is invalid, or `503` if the proxy sidecar is not running (retryable — the sidecar may have been stopped by a daemon restart and the session can be retried). Use this to rotate credentials (e.g. a short-lived git token) without rebuilding the session.
 
 #### CA generation (operator one-time step)
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All settings are configurable via environment variables. The available settings 
 - `POST /session/{session_id}/`: Run commands on the sandbox session.
 - `GET /session/{session_id}/`: Check session status — `204` if it exists (restarting it if stopped), else `404`.
 - `DELETE /session/{session_id}/`: Close the sandbox session (stops the container by default; `?force=true` removes it).
-- `PUT /session/{session_id}/egress/`: Refresh an egress session's policy and secrets without recreating the container (`204` success / `404` no session / `409` session has no egress proxy).
+- `PUT /session/{session_id}/egress/`: Refresh an egress session's policy and secrets without recreating the container (`204` success / `404` no session / `409` session has no egress proxy / `422` invalid policy body / `503` proxy sidecar not running, retryable).
 - `GET /-/health/`: Healthcheck endpoint.
 - `GET /-/version/`: Current application version.
 

--- a/daiv_sandbox/egress/manager.py
+++ b/daiv_sandbox/egress/manager.py
@@ -13,6 +13,7 @@ from daiv_sandbox.sessions import (
     SANDBOX_CA_BUNDLE,
     TYPE_EGRESS_NETWORK,
     TYPE_EGRESS_PROXY,
+    SessionUnavailableError,
     _build_single_file_tar_stream,
 )
 
@@ -133,8 +134,17 @@ class EgressProxyManager:
         truncated config.json, and PolicyStore caches that failed parse against the new mtime
         (deny-all until the next write). So stage to a temp file, then rename it over config.json
         (atomic on the same filesystem) — a reader sees the old or new file whole.
+
+        The rename uses exec_run, which requires the proxy container to be RUNNING (unlike put_archive,
+        which the daemon also accepts against a stopped container). A proxy can be stopped while its
+        session's sandbox still exists — e.g. after a daemon restart, since neither sets a restart_policy
+        and only the sandbox warm-restarts on access. Detect that and raise SessionUnavailableError so
+        the caller reports 503 (retryable) rather than an opaque 500.
         """
         proxy = self._proxy(token)
+        proxy.reload()
+        if proxy.status != "running":
+            raise SessionUnavailableError(token, f"refreshed: egress proxy is {proxy.status}")
         # config.json holds secrets, so keep mode 0o600 and own it by the proxy user (RUN_UID) so the
         # non-root mitmdump process can read it; a root-owned 0o600 file would deny-fail closed.
         with _build_single_file_tar_stream(

--- a/daiv_sandbox/egress/manager.py
+++ b/daiv_sandbox/egress/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from docker.errors import NotFound
+from docker.errors import APIError, NotFound
 
 from daiv_sandbox.config import settings
 from daiv_sandbox.egress.constants import CA_PATH, CONFIG_DIR
@@ -131,33 +131,48 @@ class EgressProxyManager:
         """Write the config JSON into the running proxy ATOMICALLY; the addon reloads on mtime change.
 
         put_archive extracts in place and is not atomic: a request landing mid-write could read a
-        truncated config.json, and PolicyStore caches that failed parse against the new mtime
-        (deny-all until the next write). So stage to a temp file, then rename it over config.json
-        (atomic on the same filesystem) — a reader sees the old or new file whole.
+        truncated config.json, and PolicyStore caches that failed parse against the new mtime (deny-all
+        until the next write) — and since mtime only advances when the file is replaced, a re-write with
+        identical bytes would not clear that cached deny-all. So stage to a temp file, then rename it
+        over config.json (atomic on the same filesystem): a reader sees the old or new file whole and
+        the mtime flips exactly once.
 
         The rename uses exec_run, which requires the proxy container to be RUNNING (unlike put_archive,
-        which the daemon also accepts against a stopped container). A proxy can be stopped while its
-        session's sandbox still exists — e.g. after a daemon restart, since neither sets a restart_policy
-        and only the sandbox warm-restarts on access. Detect that and raise SessionUnavailableError so
-        the caller reports 503 (retryable) rather than an opaque 500.
+        which the daemon also accepts against a stopped container). A proxy can be stopped or gone while
+        its session's sandbox still exists — e.g. after a daemon restart (neither sets a restart_policy,
+        and only the sandbox warm-restarts on access) or a reaper sweep. We check status up front, and
+        also translate any Docker APIError/NotFound raised during the operation (the proxy stopping
+        between the check and the mv, or having been removed) into SessionUnavailableError, so the caller
+        reports 503 (retryable) rather than an opaque 500. A failed rename leaves a benign
+        config.json.tmp behind (PolicyStore watches only config.json); the next provision overwrites it.
         """
-        proxy = self._proxy(token)
-        proxy.reload()
-        if proxy.status != "running":
-            raise SessionUnavailableError(token, f"refreshed: egress proxy is {proxy.status}")
-        # config.json holds secrets, so keep mode 0o600 and own it by the proxy user (RUN_UID) so the
-        # non-root mitmdump process can read it; a root-owned 0o600 file would deny-fail closed.
-        with _build_single_file_tar_stream(
-            "config.json.tmp", config_bytes, mode=0o600, uid=settings.RUN_UID, gid=settings.RUN_GID
-        ) as tar:
-            if not proxy.put_archive(CONFIG_DIR, tar):
-                raise RuntimeError(f"egress: failed to stage config for {token}")
-        # rename() is atomic within a filesystem: config.json flips content+mtime in one step, so a
-        # concurrent PolicyStore read never observes a partial file. `mv` preserves the temp file's
-        # RUN_UID ownership. Run as root to avoid any confdir permission edge case.
-        result = proxy.exec_run(["mv", "-f", f"{CONFIG_DIR}/config.json.tmp", f"{CONFIG_DIR}/config.json"], user="root")
-        if result.exit_code != 0:
-            raise RuntimeError(f"egress: failed to install config for {token}: [{result.exit_code}] {result.output!r}")
+        try:
+            proxy = self._proxy(token)
+            proxy.reload()
+            if proxy.status != "running":
+                raise SessionUnavailableError(token, f"refreshed: egress proxy is {proxy.status}")
+            # config.json holds secrets, so keep mode 0o600 and own it by the proxy user (RUN_UID) so the
+            # non-root mitmdump process can read it; a root-owned 0o600 file would deny-fail closed.
+            with _build_single_file_tar_stream(
+                "config.json.tmp", config_bytes, mode=0o600, uid=settings.RUN_UID, gid=settings.RUN_GID
+            ) as tar:
+                if not proxy.put_archive(CONFIG_DIR, tar):
+                    raise RuntimeError(f"egress: failed to stage config for {token}")
+            # rename() is atomic within a filesystem: config.json flips content+mtime in one step, so a
+            # concurrent PolicyStore read never observes a partial file. rename() keeps the temp file's
+            # inode (incl. RUN_UID ownership) — no chown needed. Run as root to avoid any confdir
+            # permission edge case.
+            result = proxy.exec_run(
+                ["mv", "-f", f"{CONFIG_DIR}/config.json.tmp", f"{CONFIG_DIR}/config.json"], user="root"
+            )
+            if result.exit_code != 0:
+                raise RuntimeError(
+                    f"egress: failed to install config for {token}: [{result.exit_code}] {result.output!r}"
+                )
+        except APIError as exc:
+            # The proxy stopped between the status check and the mv, or was removed (NotFound is an
+            # APIError subclass): a retryable infra fault, not a config bug — map to 503, not 500.
+            raise SessionUnavailableError(token, f"refreshed: egress proxy unavailable ({exc})") from exc
 
     def teardown(self, token: str) -> None:
         # Best-effort: an already-gone resource (NotFound) is success; any other failure is logged and

--- a/daiv_sandbox/egress/manager.py
+++ b/daiv_sandbox/egress/manager.py
@@ -127,15 +127,27 @@ class EgressProxyManager:
         return ip
 
     def provision(self, token: str, config_bytes: bytes) -> None:
-        """Write the config JSON into the running proxy; the addon reloads it on mtime change."""
+        """Write the config JSON into the running proxy ATOMICALLY; the addon reloads on mtime change.
+
+        put_archive extracts in place and is not atomic: a request landing mid-write could read a
+        truncated config.json, and PolicyStore caches that failed parse against the new mtime
+        (deny-all until the next write). So stage to a temp file, then rename it over config.json
+        (atomic on the same filesystem) — a reader sees the old or new file whole.
+        """
         proxy = self._proxy(token)
         # config.json holds secrets, so keep mode 0o600 and own it by the proxy user (RUN_UID) so the
         # non-root mitmdump process can read it; a root-owned 0o600 file would deny-fail closed.
         with _build_single_file_tar_stream(
-            "config.json", config_bytes, mode=0o600, uid=settings.RUN_UID, gid=settings.RUN_GID
+            "config.json.tmp", config_bytes, mode=0o600, uid=settings.RUN_UID, gid=settings.RUN_GID
         ) as tar:
             if not proxy.put_archive(CONFIG_DIR, tar):
-                raise RuntimeError(f"egress: failed to provision config for {token}")
+                raise RuntimeError(f"egress: failed to stage config for {token}")
+        # rename() is atomic within a filesystem: config.json flips content+mtime in one step, so a
+        # concurrent PolicyStore read never observes a partial file. `mv` preserves the temp file's
+        # RUN_UID ownership. Run as root to avoid any confdir permission edge case.
+        result = proxy.exec_run(["mv", "-f", f"{CONFIG_DIR}/config.json.tmp", f"{CONFIG_DIR}/config.json"], user="root")
+        if result.exit_code != 0:
+            raise RuntimeError(f"egress: failed to install config for {token}: [{result.exit_code}] {result.output!r}")
 
     def teardown(self, token: str) -> None:
         # Best-effort: an already-gone resource (NotFound) is success; any other failure is logged and

--- a/daiv_sandbox/main.py
+++ b/daiv_sandbox/main.py
@@ -24,6 +24,7 @@ from daiv_sandbox.locks import NoopSessionLockManager, RedisSessionLockManager, 
 from daiv_sandbox.logs import LOGGING_CONFIG
 from daiv_sandbox.reaper import start_reaper
 from daiv_sandbox.schemas import (
+    EgressConfigRequest,
     ErrorMessage,
     FsDeleteRequest,
     FsDeleteResponse,
@@ -473,6 +474,49 @@ async def get_session(
     reuse), or 404 if it does not. Lock-guarded so it can't race the reaper.
     """
     async with _workspace_executor(request, session_id):
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@app.put("/session/{session_id}/egress/", responses=common_responses, name="Refresh session egress policy")
+async def update_egress(
+    request: Request,
+    session_id: Annotated[str, FastAPIPath(title="The ID of the session whose egress policy to refresh")],
+    egress: EgressConfigRequest,
+    api_key: str = Depends(get_api_key),
+) -> Response:
+    """
+    Refresh a live session's egress policy + secrets (e.g. a fresh git token) without recreating the
+    container. Rewrites the sidecar's config.json; the proxy hot-reloads it on the next request — no
+    restart. Returns 204; 404 if the session is gone; 409 if the session has no egress proxy (a
+    network-isolated session — nothing to refresh). Lock-guarded so it can't race the reaper.
+    """
+    async with request.app.state.session_lock_manager.acquire(session_id):
+        cmd_executor = SandboxDockerSession()
+        cmd_executor.session_id = session_id
+        # Raw lookup (like DELETE): read the egress label WITHOUT warming a stopped container — the
+        # proxy sidecar runs independently of the sandbox's run state, so provisioning does not need
+        # the sandbox running.
+        try:
+            container = await asyncio.to_thread(cmd_executor.client.containers.get, session_id)
+        except NotFound as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found") from exc
+
+        token = egress_token(container)
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Session has no egress proxy; nothing to refresh"
+            )
+
+        manager = EgressProxyManager(SandboxDockerSession._get_shared_client())
+        config_bytes = json.dumps(egress.to_sidecar_config()).encode("utf-8")
+        try:
+            await asyncio.to_thread(manager.provision, token, config_bytes)
+        except Exception as exc:
+            logger.exception("Egress proxy: failed to refresh policy for session %s", session_id)
+            raise HTTPException(
+                status_code=500, detail="Egress proxy: failed to refresh policy into the sidecar"
+            ) from exc
+
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/daiv_sandbox/main.py
+++ b/daiv_sandbox/main.py
@@ -516,7 +516,9 @@ async def update_egress(
             # bug. Let the SessionUnavailableError handler map it to 503, consistent with the contract.
             raise
         except Exception as exc:
-            logger.exception("Egress proxy: failed to refresh policy for session %s", session_id)
+            logger.exception(
+                "Egress proxy: failed to refresh policy for session %s (egress token %s)", session_id, token
+            )
             raise HTTPException(
                 status_code=500, detail="Egress proxy: failed to refresh policy into the sidecar"
             ) from exc

--- a/daiv_sandbox/main.py
+++ b/daiv_sandbox/main.py
@@ -487,8 +487,8 @@ async def update_egress(
     """
     Refresh a live session's egress policy + secrets (e.g. a fresh git token) without recreating the
     container. Rewrites the sidecar's config.json; the proxy hot-reloads it on the next request — no
-    restart. Returns 204; 404 if the session is gone; 409 if the session has no egress proxy (a
-    network-isolated session — nothing to refresh). Lock-guarded so it can't race the reaper.
+    restart. Returns 204; 404 if the session is gone; 409 if the session has no egress proxy; 503 if the proxy
+    sidecar is not running (retryable). Lock-guarded so it can't race the reaper.
     """
     async with request.app.state.session_lock_manager.acquire(session_id):
         cmd_executor = SandboxDockerSession()
@@ -511,6 +511,10 @@ async def update_egress(
         config_bytes = json.dumps(egress.to_sidecar_config()).encode("utf-8")
         try:
             await asyncio.to_thread(manager.provision, token, config_bytes)
+        except SessionUnavailableError:
+            # Proxy sidecar is stopped (e.g. after a daemon restart): a retryable infra fault, not a
+            # bug. Let the SessionUnavailableError handler map it to 503, consistent with the contract.
+            raise
         except Exception as exc:
             logger.exception("Egress proxy: failed to refresh policy for session %s", session_id)
             raise HTTPException(

--- a/tests/unit_tests/test_egress_manager.py
+++ b/tests/unit_tests/test_egress_manager.py
@@ -4,7 +4,7 @@ import pytest
 from docker.errors import APIError, NotFound
 
 from daiv_sandbox.egress.manager import EgressProxyManager, exec_proxy_env
-from daiv_sandbox.sessions import EGRESS_SESSION_LABEL, TYPE_EGRESS_NETWORK, TYPE_EGRESS_PROXY
+from daiv_sandbox.sessions import EGRESS_SESSION_LABEL, TYPE_EGRESS_NETWORK, TYPE_EGRESS_PROXY, SessionUnavailableError
 
 
 def test_create_network_is_internal_and_labeled():
@@ -122,6 +122,7 @@ def test_provision_stages_to_temp_then_renames_atomically(monkeypatch):
     """provision must put_archive a temp file, then rename it over config.json (atomic swap)."""
     mgr = EgressProxyManager(Mock())
     proxy = Mock()
+    proxy.status = "running"
     proxy.put_archive.return_value = True
     proxy.exec_run.return_value = Mock(exit_code=0, output=b"")
     monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
@@ -139,9 +140,24 @@ def test_provision_raises_when_rename_fails(monkeypatch):
     """A non-zero rename exit must fail loud so a half-applied config never goes unnoticed."""
     mgr = EgressProxyManager(Mock())
     proxy = Mock()
+    proxy.status = "running"
     proxy.put_archive.return_value = True
     proxy.exec_run.return_value = Mock(exit_code=1, output=b"mv: cannot move")
     monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
 
     with pytest.raises(RuntimeError, match="failed to install config"):
         mgr.provision("tok123", b"{}")
+
+
+def test_provision_raises_session_unavailable_when_proxy_not_running(monkeypatch):
+    """A stopped proxy (e.g. after a daemon restart) must fail as a retryable 503, not a torn write."""
+    mgr = EgressProxyManager(Mock())
+    proxy = Mock()
+    proxy.status = "exited"
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    with pytest.raises(SessionUnavailableError):
+        mgr.provision("tok123", b"{}")
+
+    proxy.put_archive.assert_not_called()
+    proxy.exec_run.assert_not_called()

--- a/tests/unit_tests/test_egress_manager.py
+++ b/tests/unit_tests/test_egress_manager.py
@@ -134,6 +134,7 @@ def test_provision_stages_to_temp_then_renames_atomically(monkeypatch):
     proxy.exec_run.assert_called_once_with(
         ["mv", "-f", "/run/egress/config.json.tmp", "/run/egress/config.json"], user="root"
     )
+    proxy.reload.assert_called_once()
 
 
 def test_provision_raises_when_rename_fails(monkeypatch):
@@ -161,3 +162,41 @@ def test_provision_raises_session_unavailable_when_proxy_not_running(monkeypatch
 
     proxy.put_archive.assert_not_called()
     proxy.exec_run.assert_not_called()
+
+
+def test_provision_translates_apierror_during_mv_to_session_unavailable(monkeypatch):
+    """A proxy that stops between the status check and the mv must surface as retryable 503, not 500."""
+    mgr = EgressProxyManager(Mock())
+    proxy = Mock()
+    proxy.status = "running"
+    proxy.put_archive.return_value = True
+    proxy.exec_run.side_effect = APIError("Container abc is not running")
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    with pytest.raises(SessionUnavailableError):
+        mgr.provision("tok123", b"{}")
+
+    proxy.put_archive.assert_called_once()  # staging happened; the race is on the rename
+
+
+def test_provision_translates_notfound_proxy_to_session_unavailable(monkeypatch):
+    """A reaped/removed proxy (NotFound, an APIError subclass) must surface as retryable 503."""
+    mgr = EgressProxyManager(Mock())
+    monkeypatch.setattr(mgr, "_proxy", Mock(side_effect=NotFound("no proxy")))
+
+    with pytest.raises(SessionUnavailableError):
+        mgr.provision("tok123", b"{}")
+
+
+def test_provision_raises_when_put_archive_fails(monkeypatch):
+    """A daemon-rejected staging copy (put_archive False) must fail loud, not silently skip the write."""
+    mgr = EgressProxyManager(Mock())
+    proxy = Mock()
+    proxy.status = "running"
+    proxy.put_archive.return_value = False
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    with pytest.raises(RuntimeError, match="failed to stage config"):
+        mgr.provision("tok123", b"{}")
+
+    proxy.exec_run.assert_not_called()  # never attempt the rename if staging failed

--- a/tests/unit_tests/test_egress_manager.py
+++ b/tests/unit_tests/test_egress_manager.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from docker.errors import APIError, NotFound
@@ -116,3 +116,32 @@ def test_teardown_logs_and_continues_when_proxy_remove_errors():
     client.networks.list.return_value = [net]
     EgressProxyManager(client).teardown("tok123")  # must not raise
     net.remove.assert_called_once()  # network still cleaned up despite the proxy failure
+
+
+def test_provision_stages_to_temp_then_renames_atomically(monkeypatch):
+    """provision must put_archive a temp file, then rename it over config.json (atomic swap)."""
+    mgr = EgressProxyManager(Mock())
+    proxy = Mock()
+    proxy.put_archive.return_value = True
+    proxy.exec_run.return_value = Mock(exit_code=0, output=b"")
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    mgr.provision("tok123", b'{"policy": {"default": "allow"}, "secrets": {}}')
+
+    proxy.put_archive.assert_called_once()
+    assert proxy.put_archive.call_args.args[0] == "/run/egress"
+    proxy.exec_run.assert_called_once_with(
+        ["mv", "-f", "/run/egress/config.json.tmp", "/run/egress/config.json"], user="root"
+    )
+
+
+def test_provision_raises_when_rename_fails(monkeypatch):
+    """A non-zero rename exit must fail loud so a half-applied config never goes unnoticed."""
+    mgr = EgressProxyManager(Mock())
+    proxy = Mock()
+    proxy.put_archive.return_value = True
+    proxy.exec_run.return_value = Mock(exit_code=1, output=b"mv: cannot move")
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    with pytest.raises(RuntimeError, match="failed to install config"):
+        mgr.provision("tok123", b"{}")

--- a/tests/unit_tests/test_egress_manager.py
+++ b/tests/unit_tests/test_egress_manager.py
@@ -118,14 +118,23 @@ def test_teardown_logs_and_continues_when_proxy_remove_errors():
     net.remove.assert_called_once()  # network still cleaned up despite the proxy failure
 
 
-def test_provision_stages_to_temp_then_renames_atomically(monkeypatch):
-    """provision must put_archive a temp file, then rename it over config.json (atomic swap)."""
+def _running_proxy_mgr(monkeypatch):
+    """An EgressProxyManager whose _proxy() returns a running proxy wired for a successful provision.
+
+    Tests override a single attribute (put_archive/exec_run) to exercise one specific failure path.
+    """
     mgr = EgressProxyManager(Mock())
     proxy = Mock()
     proxy.status = "running"
     proxy.put_archive.return_value = True
     proxy.exec_run.return_value = Mock(exit_code=0, output=b"")
     monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+    return mgr, proxy
+
+
+def test_provision_stages_to_temp_then_renames_atomically(monkeypatch):
+    """provision must put_archive a temp file, then rename it over config.json (atomic swap)."""
+    mgr, proxy = _running_proxy_mgr(monkeypatch)
 
     mgr.provision("tok123", b'{"policy": {"default": "allow"}, "secrets": {}}')
 
@@ -139,12 +148,8 @@ def test_provision_stages_to_temp_then_renames_atomically(monkeypatch):
 
 def test_provision_raises_when_rename_fails(monkeypatch):
     """A non-zero rename exit must fail loud so a half-applied config never goes unnoticed."""
-    mgr = EgressProxyManager(Mock())
-    proxy = Mock()
-    proxy.status = "running"
-    proxy.put_archive.return_value = True
+    mgr, proxy = _running_proxy_mgr(monkeypatch)
     proxy.exec_run.return_value = Mock(exit_code=1, output=b"mv: cannot move")
-    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
 
     with pytest.raises(RuntimeError, match="failed to install config"):
         mgr.provision("tok123", b"{}")
@@ -166,12 +171,8 @@ def test_provision_raises_session_unavailable_when_proxy_not_running(monkeypatch
 
 def test_provision_translates_apierror_during_mv_to_session_unavailable(monkeypatch):
     """A proxy that stops between the status check and the mv must surface as retryable 503, not 500."""
-    mgr = EgressProxyManager(Mock())
-    proxy = Mock()
-    proxy.status = "running"
-    proxy.put_archive.return_value = True
+    mgr, proxy = _running_proxy_mgr(monkeypatch)
     proxy.exec_run.side_effect = APIError("Container abc is not running")
-    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
 
     with pytest.raises(SessionUnavailableError):
         mgr.provision("tok123", b"{}")
@@ -190,11 +191,8 @@ def test_provision_translates_notfound_proxy_to_session_unavailable(monkeypatch)
 
 def test_provision_raises_when_put_archive_fails(monkeypatch):
     """A daemon-rejected staging copy (put_archive False) must fail loud, not silently skip the write."""
-    mgr = EgressProxyManager(Mock())
-    proxy = Mock()
-    proxy.status = "running"
+    mgr, proxy = _running_proxy_mgr(monkeypatch)
     proxy.put_archive.return_value = False
-    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
 
     with pytest.raises(RuntimeError, match="failed to stage config"):
         mgr.provision("tok123", b"{}")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -5,7 +5,7 @@ from contextlib import AbstractAsyncContextManager, contextmanager
 from unittest.mock import Mock, patch
 
 import pytest
-from docker.errors import APIError
+from docker.errors import APIError, NotFound
 from fastapi.testclient import TestClient
 
 from daiv_sandbox import __version__
@@ -1589,10 +1589,11 @@ def test_start_session_422_when_egress_permits_nothing(client, monkeypatch, tmp_
         mock_mgr_class.return_value.create_network.assert_not_called()
 
 
-def test_configure_egress_endpoint_is_gone(client):
-    """The separate egress provisioning endpoint no longer exists; the path is unmatched (404)."""
+def test_configure_egress_endpoint_post_is_gone(client):
+    """POST to the egress path is not a registered method — only PUT is allowed.
+    Adding PUT /session/{id}/egress/ causes FastAPI to return 405 (not 404) on POST."""
     resp = client.post("/session/anything/egress/", json={"policy": {"default": "allow"}})
-    assert resp.status_code == 404, resp.text
+    assert resp.status_code == 405, resp.text
 
 
 def test_fs_glob_forwards_default_plus_request_excludes(mock_session, client, monkeypatch):
@@ -1626,3 +1627,46 @@ def test_fs_grep_forwards_default_plus_request_excludes(mock_session, client, mo
     call = mock_session.grep.call_args
     passed = call.args[3] if len(call.args) > 3 else call.kwargs["excludes"]
     assert tuple(passed) == (".git", "vendor")
+
+
+def test_update_egress_refreshes_running_session(client):
+    """PUT rewrites the sidecar policy via the manager, keyed on the session's egress token."""
+    with (
+        patch("daiv_sandbox.main.SandboxDockerSession") as cls,
+        patch("daiv_sandbox.main.EgressProxyManager") as mock_mgr_class,
+    ):
+        cmd = cls.return_value
+        cmd.session_id = "sbx"
+        cmd.client.containers.get.return_value = Mock(labels={"daiv.sandbox.egress": "tok123"})
+
+        resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
+
+        assert resp.status_code == 204
+        mock_mgr_class.return_value.provision.assert_called_once()
+        assert mock_mgr_class.return_value.provision.call_args.args[0] == "tok123"
+
+
+def test_update_egress_404_when_session_missing(client):
+    with patch("daiv_sandbox.main.SandboxDockerSession") as cls:
+        cls.return_value.client.containers.get.side_effect = NotFound("gone")
+        resp = client.put("/session/missing/egress/", json=_EGRESS_PAYLOAD)
+        assert resp.status_code == 404
+
+
+def test_update_egress_409_when_session_has_no_egress(client):
+    with patch("daiv_sandbox.main.SandboxDockerSession") as cls:
+        cls.return_value.client.containers.get.return_value = Mock(labels={})  # no egress label
+        resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
+        assert resp.status_code == 409
+
+
+def test_update_egress_422_on_invalid_policy(client):
+    # deny-default with no rules "permits nothing" → rejected by EgressConfigRequest validation.
+    resp = client.put("/session/sbx/egress/", json={"policy": {"default": "deny", "rules": []}})
+    assert resp.status_code == 422
+
+
+def test_update_egress_missing_api_key(client):
+    client.headers = {}
+    resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
+    assert resp.status_code == 403

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1645,6 +1645,7 @@ def test_update_egress_refreshes_running_session(client):
         assert resp.status_code == 204
         mock_mgr_class.return_value.provision.assert_called_once()
         assert mock_mgr_class.return_value.provision.call_args.args[0] == "tok123"
+        assert b"github.com" in mock_mgr_class.return_value.provision.call_args.args[1]
 
 
 def test_update_egress_404_when_session_missing(client):
@@ -1685,3 +1686,26 @@ def test_update_egress_503_when_proxy_not_running(client):
         resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
 
         assert resp.status_code == 503
+
+
+def test_update_egress_500_on_unexpected_provision_error(client):
+    """A genuine provision fault (e.g. a non-zero mv) is an internal error, not a retryable 503."""
+    with (
+        patch("daiv_sandbox.main.SandboxDockerSession") as cls,
+        patch("daiv_sandbox.main.EgressProxyManager") as mock_mgr_class,
+    ):
+        cls.return_value.client.containers.get.return_value = Mock(labels={"daiv.sandbox.egress": "tok123"})
+        mock_mgr_class.return_value.provision.side_effect = RuntimeError("egress: failed to install config")
+
+        resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
+
+        assert resp.status_code == 500
+
+
+def test_update_egress_returns_conflict_when_session_is_locked(client, monkeypatch):
+    monkeypatch.setattr(app.state, "session_lock_manager", BusySessionLockManager())
+
+    resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
+
+    assert resp.status_code == 409
+    assert resp.json() == {"detail": "Session is busy"}

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -13,6 +13,7 @@ from daiv_sandbox.config import settings
 from daiv_sandbox.locks import SessionBusyError
 from daiv_sandbox.main import app
 from daiv_sandbox.schemas import RunResult
+from daiv_sandbox.sessions import SessionUnavailableError
 
 # Minimal egress payload used across egress-enabled start_session tests.
 _EGRESS_PAYLOAD = {"policy": {"default": "deny", "rules": [{"host": "github.com", "methods": ["*"]}]}}
@@ -1670,3 +1671,17 @@ def test_update_egress_missing_api_key(client):
     client.headers = {}
     resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
     assert resp.status_code == 403
+
+
+def test_update_egress_503_when_proxy_not_running(client):
+    """A stopped proxy sidecar surfaces as a retryable 503, not an opaque 500."""
+    with (
+        patch("daiv_sandbox.main.SandboxDockerSession") as cls,
+        patch("daiv_sandbox.main.EgressProxyManager") as mock_mgr_class,
+    ):
+        cls.return_value.client.containers.get.return_value = Mock(labels={"daiv.sandbox.egress": "tok123"})
+        mock_mgr_class.return_value.provision.side_effect = SessionUnavailableError("tok123", "refreshed")
+
+        resp = client.put("/session/sbx/egress/", json=_EGRESS_PAYLOAD)
+
+        assert resp.status_code == 503


### PR DESCRIPTION
## What

Adds an endpoint that refreshes a **live** session's egress policy + secrets (e.g. a rotated git token) without recreating the container, so daiv can hand a resumed session a fresh credential. The mitmproxy sidecar already hot-reloads `/run/egress/config.json` on mtime change; this branch makes that write atomic and exposes a `PUT` to trigger it.

## Changes

- **`fix(egress): write sidecar config atomically (temp + rename)`** — `EgressProxyManager.provision` now stages the config to `config.json.tmp` (`put_archive`) then `mv -f`'s it over `config.json`. `put_archive` extracts in place and is not atomic: a request landing mid-write could read a truncated file, and `PolicyStore` then caches that failed parse against the new mtime (deny-all until the *next* write). The rename flips content+mtime in one step, so a concurrent reader sees the old or new file whole.
- **`feat(egress): add PUT /session/{id}/egress/`** — refreshes a session's egress policy + secrets in place. Reuses the existing `EgressConfigRequest` wire schema (no new schema type — daiv's `schemas.dump.json` is unaffected). Lock-guarded; raw container lookup (like `DELETE`, no warm restart). Contract: `204` refreshed / `404` no session / `409` session has no egress proxy / `422` invalid policy / `403` auth.
- **`fix(egress): return 503 when refreshing a session whose proxy sidecar is stopped`** — the atomic rename uses `exec_run`, which (unlike `put_archive`) requires the proxy to be running. A proxy can be stopped while its sandbox still exists (e.g. after a daemon restart, since neither sets a `restart_policy` and only the sandbox warm-restarts). `provision` now detects a non-running proxy and raises `SessionUnavailableError`, mapped to `503` (retryable) — matching the repo's documented "Docker fault on restart/stop → 503" contract instead of an opaque 500.

## Tests

- New unit tests for the atomic temp+rename swap, the rename-failure path, and the stopped-proxy → 503 path (manager + endpoint level); five endpoint tests covering all status codes.
- Full unit suite: **397 passed**, ruff clean.

## Rollout

Deploy **before** the daiv-side change for the full benefit, but order is not strict: an older daiv never calls the endpoint, and a newer daiv hitting an older sandbox gets `404` and recreates the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
