### PR TITLE
fix(egress): self-heal a dead proxy so a warm session keeps egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pipeline exit codes were masked by the last command; commands now run with `pipefail` enabled so a failing stage in a pipeline (e.g. `cmd1 | cmd2`) correctly propagates a non-zero exit code.
 - Invalid bytes in a command's output raised `UnicodeDecodeError`; such bytes are now replaced with U+FFFD instead of failing the request.
+- Egress proxy now self-heals: the sidecar carries a bounded `on-failure` restart policy and is warm-restarted when its internal IP is resolved, so a session no longer loses egress permanently after the proxy is OOM-killed or lost to a daemon restart while the sandbox stays warm.
 
 ## [0.4.0] - 2026-02-22
 

--- a/daiv_sandbox/egress/manager.py
+++ b/daiv_sandbox/egress/manager.py
@@ -80,6 +80,15 @@ class EgressProxyManager:
             "labels": labels,
             "network": network_name,  # internal NIC
             "runtime": settings.EGRESS_PROXY_RUNTIME,
+            # Auto-recover the sidecar after a crash/OOM (non-zero exit), so a still-warm session does
+            # not lose egress. A backstop, not the whole story: on-failure reliably covers a crash/OOM
+            # but — unlike always/unless-stopped — does not guarantee a restart across a daemon restart;
+            # proxy_internal_ip's warm-restart-on-access is the real safety net for that case (and for
+            # exhausted retries). on-failure — NOT always/unless-stopped — so a proxy that OOMs on every
+            # boot can't thrash forever (bounded by MaximumRetryCount) and a clean exit-0 shutdown is
+            # left alone. teardown force-removes the container, which overrides the policy, so this never
+            # fights cleanup.
+            "restart_policy": {"Name": "on-failure", "MaximumRetryCount": 5},
         }
         if settings.EGRESS_PROXY_MEMORY_BYTES:
             create_kwargs["mem_limit"] = settings.EGRESS_PROXY_MEMORY_BYTES
@@ -119,8 +128,25 @@ class EgressProxyManager:
 
     def proxy_internal_ip(self, token: str) -> str:
         network_name = self._internal_network_name(token)
-        proxy = self._proxy(token)
-        proxy.reload()
+        # A sidecar can die (OOM, crash) while its session's sandbox stays warm — Docker then releases
+        # its endpoint IP, so a stopped proxy reads back with no IPAddress. The restart policy (see
+        # start_proxy) recovers a crash/OOM, but a request can arrive before it fires, its retries can be
+        # exhausted, or a daemon restart may have left the proxy down. Warm-restart it here too — the
+        # same restart-on-access idea as SandboxDockerSession._get_container — so the session self-heals
+        # instead of losing egress until it is explicitly recreated. Safe because the confdir
+        # (/run/egress: the injected CA, plus config.json once provisioned) is on the container's
+        # writable layer, so a restarted proxy comes back with its CA intact. Like provision(), any
+        # Docker APIError (missing proxy, or one stopping/vanishing mid-restart; NotFound is a subclass)
+        # becomes a retryable SessionUnavailableError (503) rather than an opaque 500.
+        try:
+            proxy = self._proxy(token)
+            proxy.reload()
+            if proxy.status != "running":
+                logger.warning("egress: proxy for %s is %s; restarting", token, proxy.status)
+                proxy.restart()
+                proxy.reload()  # restart() does not refresh attrs; reload() surfaces the fresh IP
+        except APIError as exc:
+            raise SessionUnavailableError(token, f"egress proxy unavailable ({exc})") from exc
         nets = proxy.attrs["NetworkSettings"]["Networks"]
         ip = nets.get(network_name, {}).get("IPAddress")
         if not ip:
@@ -139,8 +165,10 @@ class EgressProxyManager:
 
         The rename uses exec_run, which requires the proxy container to be RUNNING (unlike put_archive,
         which the daemon also accepts against a stopped container). A proxy can be stopped or gone while
-        its session's sandbox still exists — e.g. after a daemon restart (neither sets a restart_policy,
-        and only the sandbox warm-restarts on access) or a reaper sweep. We check status up front, and
+        its session's sandbox still exists — e.g. after a daemon restart or a reaper sweep. (The proxy
+        carries an on-failure restart_policy and proxy_internal_ip warm-restarts it on access, but
+        provision deliberately does NOT restart: it only stages+renames config into an already-running
+        proxy, so it fails 503 here and leaves recovery to those paths.) We check status up front, and
         also translate any Docker APIError/NotFound raised during the operation (the proxy stopping
         between the check and the mv, or having been removed) into SessionUnavailableError, so the caller
         reports 503 (retryable) rather than an opaque 500. A failed rename leaves a benign

--- a/tests/unit_tests/test_egress_manager.py
+++ b/tests/unit_tests/test_egress_manager.py
@@ -40,6 +40,26 @@ def test_start_proxy_creates_dualhomed_labeled_container(monkeypatch):
     proxy.start.assert_called_once()
 
 
+def test_start_proxy_sets_onfailure_restart_policy(monkeypatch):
+    """The sidecar must carry an on-failure restart policy so the daemon auto-recovers it after a
+    crash/OOM (non-zero exit) — otherwise a dead proxy poisons a still-warm session's egress until a
+    request happens to warm-restart it. It must NOT be `always`/`unless-stopped`: a proxy that OOMs on
+    every boot would thrash forever on a memory-starved host; on-failure is bounded (MaximumRetryCount)
+    and leaves a clean exit-0 shutdown alone."""
+    from daiv_sandbox.config import settings
+
+    monkeypatch.setattr(settings, "EGRESS_PROXY_IMAGE", "img:test")
+    monkeypatch.setattr(settings, "EGRESS_PROXY_NETWORK", "egress-net")
+    client = MagicMock()
+    mgr = EgressProxyManager(client)
+
+    mgr.start_proxy("tok123", "daiv-egress-tok123", ca_pem=b"PEM")
+
+    policy = client.containers.create.call_args.kwargs["restart_policy"]
+    assert policy["Name"] == "on-failure"
+    assert policy.get("MaximumRetryCount", 0) > 0  # bounded, so it can't thrash forever
+
+
 def test_exec_proxy_env_points_clients_at_proxy_and_ca():
     env = exec_proxy_env("10.0.0.2", 8080)
     assert env["HTTPS_PROXY"] == "http://10.0.0.2:8080"
@@ -116,6 +136,77 @@ def test_teardown_logs_and_continues_when_proxy_remove_errors():
     client.networks.list.return_value = [net]
     EgressProxyManager(client).teardown("tok123")  # must not raise
     net.remove.assert_called_once()  # network still cleaned up despite the proxy failure
+
+
+def _proxy_with_ip(ip: str, network_name: str = "daiv-egress-tok123") -> Mock:
+    proxy = Mock()
+    proxy.attrs = {"NetworkSettings": {"Networks": {network_name: {"IPAddress": ip}}}}
+    return proxy
+
+
+def test_proxy_internal_ip_returns_ip_of_running_proxy_without_restart(monkeypatch):
+    """The common path: a running proxy with an IP is resolved directly, never restarted."""
+    mgr = EgressProxyManager(Mock())
+    proxy = _proxy_with_ip("10.1.2.3")
+    proxy.status = "running"
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    assert mgr.proxy_internal_ip("tok123") == "10.1.2.3"
+    proxy.restart.assert_not_called()
+
+
+def test_proxy_internal_ip_restarts_stopped_proxy_and_reresolves(monkeypatch):
+    """A proxy sidecar can be OOM-killed (or lost to a daemon restart) while its session's sandbox
+    stays warm, and the restart policy may not have fired yet. proxy_internal_ip must warm-restart the
+    stopped proxy — same restart-on-access idea as the sandbox — and return the fresh IP, so the
+    session self-heals instead of silently losing egress forever.
+
+    The fresh IP is modeled to appear only on the reload() *after* restart() — as with real docker-py,
+    where restart() does not refresh .attrs — so this test guards the reload-after-restart call: drop
+    it and the method reads back the stale (empty) IP and this assertion fails."""
+    mgr = EgressProxyManager(Mock())
+    proxy = _proxy_with_ip("")  # stopped: Docker releases the endpoint IP
+    proxy.status = "exited"
+
+    def _reload():
+        # docker-py refreshes .attrs on reload(), not on restart(): the fresh endpoint IP only appears
+        # on the reload() *after* restart(). Keying the side effect on restart.called guards that
+        # post-restart reload — drop it and attrs stay empty and the assertion fails with "has no IP".
+        if proxy.restart.called:
+            proxy.attrs = _proxy_with_ip("10.9.9.9").attrs
+
+    proxy.reload.side_effect = _reload
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    assert mgr.proxy_internal_ip("tok123") == "10.9.9.9"
+    proxy.restart.assert_called_once()
+    assert proxy.reload.call_count == 2  # once before the status check, once after restart
+
+
+def test_proxy_internal_ip_raises_session_unavailable_when_restart_fails(monkeypatch):
+    """If the dead proxy cannot be restarted (daemon/runtime fault), surface a retryable
+    SessionUnavailableError (503) rather than the opaque "has no IP" RuntimeError."""
+    mgr = EgressProxyManager(Mock())
+    proxy = _proxy_with_ip("")
+    proxy.status = "exited"
+    proxy.restart.side_effect = APIError("daemon refused restart")
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    with pytest.raises(SessionUnavailableError):
+        mgr.proxy_internal_ip("tok123")
+
+
+def test_proxy_internal_ip_raises_when_running_proxy_has_no_ip(monkeypatch):
+    """A genuinely anomalous state — proxy running yet holding no IP on its internal network — still
+    raises the explicit RuntimeError (it is not a stopped-proxy case, so no restart is attempted)."""
+    mgr = EgressProxyManager(Mock())
+    proxy = _proxy_with_ip("")
+    proxy.status = "running"
+    monkeypatch.setattr(mgr, "_proxy", lambda token: proxy)
+
+    with pytest.raises(RuntimeError, match="has no IP"):
+        mgr.proxy_internal_ip("tok123")
+    proxy.restart.assert_not_called()
 
 
 def _running_proxy_mgr(monkeypatch):


### PR DESCRIPTION
## Problem

Sentry `DAIV-SANDBOX-A`: `RuntimeError: egress: proxy for <tok> has no IP on daiv-egress-<tok>` / `egress: could not resolve proxy endpoint`.

The per-session mitmproxy egress sidecar can be **OOM-killed** (verified in production: `exit 137`, `OOMKilled=true`, on a memory-starved host with no per-container cap) or lost to a daemon restart — **while its sandbox container stays warm**. Nothing brings the dead proxy back:

- only the *sandbox* warm-restarts on access (`SandboxDockerSession._get_container`);
- the reaper only tears a triad down once the *sandbox* is gone, so it correctly leaves — but never repairs — a dead-proxy / live-sandbox pair.

`proxy_internal_ip` then read the stopped proxy (Docker releases the endpoint IP → empty `IPAddress`), raised a vague `RuntimeError`, which the caller (`_egress_environment`) swallowed to `{}`. The session was silently poisoned: local git worked, anything networked failed against a dead proxy.

## Fix

1. **Self-heal** — `proxy_internal_ip` warm-restarts a non-running proxy (mirroring the sandbox's restart-on-access) and re-resolves the IP. Safe because `/run/egress` (the injected CA + `config.json`) is on the container's writable layer (not a tmpfs), so a restart comes back provisioned. Docker faults now map to a retryable `SessionUnavailableError` (503) instead of an opaque error.
2. **Defense-in-depth** — the sidecar is created with a bounded `on-failure` (max 5) restart policy, so the daemon auto-recovers it after a crash/OOM even before a request arrives. `on-failure` (not `always`/`unless-stopped`) so a proxy that OOMs on every boot can't thrash forever and a clean exit-0 is left alone; teardown force-removes, overriding the policy.

## Testing

- 5 new unit tests in `test_egress_manager.py`: restart-policy shape; running → resolve (no restart); stopped → restart → re-resolve (guards the post-restart `reload()`); restart-fails → 503; running-but-no-IP → `RuntimeError`.
- Full unit suite green, ruff clean.

## Follow-ups (ops, not in this PR)

The production trigger is host memory pressure on the daivagent box (4 GB, no swap; the global OOM-killer took the proxy). Recommend setting `DAIV_SANDBOX_EGRESS_PROXY_MEMORY_BYTES` to cap the proxy's blast radius and adding swap / resizing the host.
