### PR TITLE
perf(egress): stream large bodies through the sidecar instead of buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The egress sidecar now streams message bodies larger than 256KB (`stream_large_bodies`) instead of buffering them whole in memory. Large transfers through the proxy (git packfiles, concurrent wheel downloads) previously accumulated as full-body buffers and parked the sidecar's RSS at the peak (400MB+ observed); the egress addon never inspects bodies, so streaming is behavior-neutral.
 - Bumped `sentry-sdk` to 2.65.0, `mypy` to 2.3.0, and `pyproject-fmt` to 2.25.3.
 - Network access is now requested by supplying an `egress` policy block on `POST /session/`; omitting it isolates the sandbox (`network_mode=none`). There is no longer a separate `POST /session/{id}/egress/` endpoint, and `network_enabled` has been removed from the start-session request. **Breaking change**
 - `DELETE /session/{id}/` now _stops_ the container instead of removing it, preserving it for warm reuse; it is reclaimed later by the reaper, or immediately when `?force=true` is passed. **Breaking change** — the container is no longer removed on close by default.

--- a/egress_proxy/Dockerfile
+++ b/egress_proxy/Dockerfile
@@ -15,5 +15,8 @@ RUN mkdir -p /run/egress && chown 1000:1000 /run/egress
 
 # `--mode regular` = forward proxy; confdir holds mitmproxy-ca.pem (provisioned by the server before
 # start). --set connection_strategy=lazy so unintercepted (passthrough) flows aren't eagerly opened.
+# stream_large_bodies: without it mitmproxy buffers every body whole (git packfiles, concurrent uv
+# wheel downloads → 400MB+ RSS kept forever). Streamed flows skip body hooks; the addon has none.
 CMD ["mitmdump", "--mode", "regular", "--listen-host", "0.0.0.0", "--listen-port", "8080", \
-     "--set", "confdir=/run/egress", "--set", "connection_strategy=lazy", "-s", "/addon/addon.py"]
+     "--set", "confdir=/run/egress", "--set", "connection_strategy=lazy", \
+     "--set", "stream_large_bodies=256k", "-s", "/addon/addon.py"]


### PR DESCRIPTION
## Why

Egress proxy sidecars were observed parked at **408MB RSS while idle for a week** (daivagent, 2026-07-30 memory incident). Two compounding causes:

1. mitmproxy's default behavior buffers every request/response body **whole in memory** before forwarding, so addons get a chance to inspect complete bodies. The sidecar's traffic is the worst case for this: git clone packfiles and uv/pip wheel downloads, where uv fetches many wheels concurrently — several hundred-MB bodies buffered simultaneously during a `uv sync`.
2. CPython/glibc don't return freed heap to the OS, so RSS stays at the transfer peak forever after a single big clone/sync.

The buffering buys nothing here: the egress addon never reads a body. Its only hooks are `http_connect` (host allow/deny), `tls_clienthello` (intercept vs passthrough), and `request` (auth-header injection).

## What changed

`--set stream_large_bodies=256k` added to the mitmdump CMD: bodies above 256KB are forwarded in chunks instead of accumulating. mitmproxy skips body-modifying hooks for streamed flows — behavior-neutral since the addon has none, and request-header injection happens before the body regardless. Policy enforcement (CONNECT filtering, SNI passthrough selection, method limits) is untouched: it all operates on connection metadata and headers.

`DAIV_SANDBOX_EGRESS_PROXY_MEMORY_BYTES` remains useful as a backstop (WebSocket messages are still buffered per-message, and it bounds any leak), but with streaming the sidecar's steady state should sit near its ~50-100MB baseline, so deployments can cap it much tighter.

## Verification

- `make lint-egress-sidecar` passes.
- Image builds; mitmdump 12.1.2 boots and stays running with the new option (an unknown/invalid option crashes it at startup).