### PR TITLE
fix(egress): Pull the sidecar image on demand when it is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline exit codes were masked by the last command; commands now run with `pipefail` enabled so a failing stage in a pipeline (e.g. `cmd1 | cmd2`) correctly propagates a non-zero exit code.
 - Invalid bytes in a command's output raised `UnicodeDecodeError`; such bytes are now replaced with U+FFFD instead of failing the request.
 - Egress proxy now self-heals: the sidecar carries a bounded `on-failure` restart policy and is warm-restarted when its internal IP is resolved, so a session no longer loses egress permanently after the proxy is OOM-killed or lost to a daemon restart while the sandbox stays warm.
+- `POST /session/` carrying an `egress` block returned `503 Egress proxy failed to start` for every new session whenever the egress sidecar image was absent from the host — a fresh deployment, or the image reclaimed by an aggressive cleanup (`docker image prune -a`, `docker system prune -a`, `docker rmi`). The sidecar image is now pulled on demand and the container creation retried. A registry fault during that pull (unreachable registry, rate limit, no disk space) is reported as a pull failure naming the image, instead of resurfacing as the misleading `ImageNotFound` that docker-py's `images.pull` produces when it discards the daemon's error stream.
 
 ## [0.4.0] - 2026-02-22
 

--- a/daiv_sandbox/egress/manager.py
+++ b/daiv_sandbox/egress/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from docker.errors import APIError, NotFound
+from docker.errors import APIError, ImageNotFound, NotFound
 
 from daiv_sandbox.config import settings
 from daiv_sandbox.egress.constants import CA_PATH, CONFIG_DIR
@@ -91,7 +91,13 @@ class EgressProxyManager:
         if settings.EGRESS_PROXY_CPUS:
             create_kwargs["nano_cpus"] = int(settings.EGRESS_PROXY_CPUS * 1e9)
 
-        proxy = self.client.containers.create(**create_kwargs)
+        # Not containers.run (which would auto-pull): the CA must land in the confdir before the proxy
+        # boots, so the container has to exist created-but-not-running first.
+        try:
+            proxy = self.client.containers.create(**create_kwargs)
+        except ImageNotFound:
+            self._pull_sidecar_image(create_kwargs["image"])
+            proxy = self.client.containers.create(**create_kwargs)
         # Self-cleaning: any failure between create and a successful start must remove the just-created
         # container, so this never leaks even when a caller forgot to wrap it in teardown (the caller's
         # teardown then becomes belt-and-suspenders rather than the only safety net).
@@ -121,6 +127,17 @@ class EgressProxyManager:
             raise
         logger.info("egress: started proxy %s for token %s", proxy.short_id, token)
         return proxy
+
+    def _pull_sidecar_image(self, image: str) -> None:
+        """Pull the sidecar image on demand, reporting a registry fault as a pull failure."""
+        logger.warning("egress: sidecar image %s missing locally; pulling", image)
+        try:
+            self.client.images.pull(image)
+        except APIError as exc:
+            # images.pull discards the daemon's errorDetail stream and then re-inspects, so a mid-pull
+            # ENOSPC or rate-limit arrives here as the same ImageNotFound that sent us to this branch.
+            raise RuntimeError(f"egress: cannot pull sidecar image {image}: {exc}") from exc
+        logger.info("egress: pulled sidecar image %s", image)
 
     def ensure_proxy_running(self, token: str) -> Container:
         """Return the session's proxy, warm-restarting it if it is not running.

--- a/tests/unit_tests/test_egress_manager.py
+++ b/tests/unit_tests/test_egress_manager.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, Mock
 
 import pytest
-from docker.errors import APIError, NotFound
+from docker.errors import APIError, ImageNotFound, NotFound
 
 from daiv_sandbox.egress.manager import EgressProxyManager, exec_proxy_env
 from daiv_sandbox.sessions import EGRESS_SESSION_LABEL, TYPE_EGRESS_NETWORK, TYPE_EGRESS_PROXY, SessionUnavailableError
@@ -38,6 +38,81 @@ def test_start_proxy_creates_dualhomed_labeled_container(monkeypatch):
     client.networks.get.return_value.connect.assert_called_once_with(proxy)
     assert proxy.put_archive.called  # CA shipped into confdir
     proxy.start.assert_called_once()
+    # The warm path must not reach the registry, nor create the container twice.
+    client.images.pull.assert_not_called()
+    client.containers.create.assert_called_once()
+
+
+def test_start_proxy_pulls_and_retries_when_sidecar_image_missing(monkeypatch):
+    """A host that reclaimed the sidecar image (`docker image prune -a`, or one that never pulled it)
+    must self-heal instead of failing every new egress session."""
+    from daiv_sandbox.config import settings
+
+    monkeypatch.setattr(settings, "EGRESS_PROXY_IMAGE", "img:test")
+    monkeypatch.setattr(settings, "EGRESS_PROXY_NETWORK", "egress-net")
+    client = MagicMock()
+    proxy = MagicMock()
+    client.containers.create.side_effect = [ImageNotFound("No such image: img:test"), proxy]
+    mgr = EgressProxyManager(client)
+
+    assert mgr.start_proxy("tok123", "daiv-egress-tok123", ca_pem=b"PEM") is proxy
+
+    client.images.pull.assert_called_once_with("img:test")
+    assert client.containers.create.call_count == 2  # the retry after the pull is what heals it
+    proxy.start.assert_called_once()
+
+
+def test_start_proxy_retries_the_create_exactly_once(monkeypatch):
+    """An image still absent after a successful pull must give up rather than loop: an unbounded
+    pull-and-retry would hang the request while hammering the registry."""
+    from daiv_sandbox.config import settings
+
+    monkeypatch.setattr(settings, "EGRESS_PROXY_IMAGE", "img:test")
+    monkeypatch.setattr(settings, "EGRESS_PROXY_NETWORK", "egress-net")
+    client = MagicMock()
+    client.containers.create.side_effect = ImageNotFound("No such image: img:test")
+    mgr = EgressProxyManager(client)
+
+    with pytest.raises(ImageNotFound):
+        mgr.start_proxy("tok123", "daiv-egress-tok123", ca_pem=b"PEM")
+
+    assert client.containers.create.call_count == 2
+    client.images.pull.assert_called_once_with("img:test")
+
+
+def test_start_proxy_reports_registry_fault_instead_of_image_not_found(monkeypatch):
+    """A registry fault (ENOSPC, rate limit) must surface naming the image, not as the misleading
+    ImageNotFound that docker-py's images.pull re-raises when the pull itself failed."""
+    from daiv_sandbox.config import settings
+
+    monkeypatch.setattr(settings, "EGRESS_PROXY_IMAGE", "img:test")
+    monkeypatch.setattr(settings, "EGRESS_PROXY_NETWORK", "egress-net")
+    client = MagicMock()
+    client.containers.create.side_effect = ImageNotFound("No such image: img:test")
+    client.images.pull.side_effect = ImageNotFound("No such image: img:test")
+    mgr = EgressProxyManager(client)
+
+    with pytest.raises(RuntimeError, match="cannot pull sidecar image img:test"):
+        mgr.start_proxy("tok123", "daiv-egress-tok123", ca_pem=b"PEM")
+
+    assert client.containers.create.call_count == 1  # no retry once the pull is known to have failed
+
+
+def test_start_proxy_propagates_daemon_fault_without_pulling(monkeypatch):
+    """A create failure that is not a missing image must propagate untouched — widening the catch from
+    ImageNotFound to APIError would turn a daemon fault into a pointless registry pull."""
+    from daiv_sandbox.config import settings
+
+    monkeypatch.setattr(settings, "EGRESS_PROXY_IMAGE", "img:test")
+    monkeypatch.setattr(settings, "EGRESS_PROXY_NETWORK", "egress-net")
+    client = MagicMock()
+    client.containers.create.side_effect = APIError("500 Server Error: daemon unreachable")
+    mgr = EgressProxyManager(client)
+
+    with pytest.raises(APIError):
+        mgr.start_proxy("tok123", "daiv-egress-tok123", ca_pem=b"PEM")
+
+    client.images.pull.assert_not_called()
 
 
 def test_start_proxy_sets_onfailure_restart_policy(monkeypatch):


### PR DESCRIPTION
## Problem

Every new session carrying an `egress` block failed with `503 Egress proxy failed to start` whenever the egress sidecar image was absent from the host — either a fresh host, or the image reclaimed by a cleanup job. `containers.create` does not auto-pull (only `containers.run` does), so the daemon returned `ImageNotFound` and the triad never started.

Reported by Sentry as `DAIV-B0`. Root cause was operational: the production host runs a weekly image cleanup.

## Fix

Attempt the create, and on `ImageNotFound` pull the image and retry — docker-py's own idiom, the same shape `containers.run` uses internally:

```python
try:
    proxy = self.client.containers.create(**create_kwargs)
except ImageNotFound:
    self._pull_sidecar_image(create_kwargs["image"])
    proxy = self.client.containers.create(**create_kwargs)
```

Reactive rather than a proactive `images.get` because it adds **zero** daemon round-trips on the warm path and closes the window where a cleanup lands between the check and the create — precisely the race in the reported incident. `containers.run` is not usable here: the CA has to be injected into the confdir before the proxy boots, which requires the container to exist created-but-not-running.

A registry fault during the pull is now reported as a pull failure naming the image. `docker-py`'s `images.pull` discards the daemon's `errorDetail` stream and then re-inspects ([`models/images.py`](https://github.com/docker/docker-py/blob/7.2.0/docker/models/images.py)), so an ENOSPC mid-extract or a registry rate limit would otherwise resurface as the same misleading `ImageNotFound` this change exists to remove. That matters here because a host that prunes weekly is often a host short on disk.

The catch stays narrowed to `ImageNotFound`, so a genuine daemon fault still propagates to the caller's retryable 503 rather than triggering a pointless registry pull.

## Verification

- `make lint` clean; 463 unit tests; 3 egress integration tests against a live daemon.
- **Real-daemon check of the new branch** (integration tests can't cover it — they skip or no-op when the image is present):
  - absent-but-pullable image → pull fired, create succeeded on retry;
  - unpullable tag → `egress: cannot pull sidecar image …: 500 Server Error`, not a bare `ImageNotFound`;
  - no containers or networks left behind in either case.
- Mutation testing kills 7 of 8 mutants — feature removal, pull-moved-after-create, wrong image ref, catch widened to `APIError`, unreachable error wrapper, unconditional pull, and unbounded retry loop. The survivor only changes a log level, which no test asserts by design.

## Reviewer notes — this fix is deliberately partial

1. **Warm sessions are still lost to the same cleanup.** `docker system prune -a` also reclaims stopped *containers*, and a non-force session close leaves the sidecar stopped on purpose. A resumed session then 503s on every retry, forever, until the reaper collects it. Not addressed here.
2. **Pin the sidecar by digest.** With lazy pulling, a cleanup followed by a pull silently fetches whatever the mutable tag points at. The sidecar embeds `egress/{addon,policy,constants}.py` verbatim while the service generates its `config.json`, so a skewed pair is a schema mismatch in a component that fails **open** on a broken addon.
3. **`images.pull` has no timeout.** `APIClient.pull` passes `timeout=None` explicitly and `_set_request_timeout` uses `setdefault`, so the 60s client default is bypassed. A stalled registry hangs the request indefinitely and pins an `asyncio.to_thread` worker. Pre-existing on the base-image path too; tracked separately.

The durable fix remains operational: exclude the sidecar image and daiv-sandbox containers from the cleanup job, or pre-pull in the deploy.